### PR TITLE
fixed links to the homepage

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -1,7 +1,7 @@
 {{!< default}}
 
 <section class="archives">
-  <a class="nav nav--black" href="/">
+  <a class="nav nav--black" href="{{@blog.url}}">
     <i class="fa fa-lg fa-arrow-left"></i>
     <span>Back to Posts</span>
   </a>

--- a/post.hbs
+++ b/post.hbs
@@ -5,7 +5,7 @@
 <article>
 
   <header class="section-padding--lg mast rellax" data-rellax-speed="-4">
-    <a class="nav nav--white" href="/">
+    <a class="nav nav--white" href="{{@blog.url}}">
       <i class="fa fa-lg fa-arrow-left"></i>
       <span>Back to Posts</span>
     </a>


### PR DESCRIPTION
The href on the links to the homepage being set to `/` is broken when ghost gets installed in a subfolder.